### PR TITLE
doesn't create deferred struct until we parse arguments

### DIFF
--- a/.changeset/nice-pears-join.md
+++ b/.changeset/nice-pears-join.md
@@ -1,0 +1,5 @@
+---
+'c2pa-node': patch
+---
+
+fixes issue where we leave unsettled promises in the rust layer, which caused unhandled promise rejections in the js layer

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ target
 **/.DS_Store
 npm-debug.log*
 generated
+package-lock.json
 dist
 .vscode
 .idea

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,7 +61,7 @@ An asset that can either be in memory or on disk
 
 #### Defined in
 
-[bindings.ts:154](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/bindings.ts#L154)
+[bindings.ts:154](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/bindings.ts#L154)
 
 ___
 
@@ -71,7 +71,7 @@ ___
 
 #### Defined in
 
-[lib/manifestBuilder.ts:21](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/lib/manifestBuilder.ts#L21)
+[lib/manifestBuilder.ts:21](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/lib/manifestBuilder.ts#L21)
 
 ___
 
@@ -81,7 +81,7 @@ ___
 
 #### Defined in
 
-[index.ts:28](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/index.ts#L28)
+[index.ts:28](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/index.ts#L28)
 
 ___
 
@@ -99,7 +99,7 @@ ___
 
 #### Defined in
 
-[index.ts:18](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/index.ts#L18)
+[index.ts:18](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/index.ts#L18)
 
 ___
 
@@ -109,7 +109,7 @@ ___
 
 #### Defined in
 
-[lib/hash.ts:17](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/lib/hash.ts#L17)
+[lib/hash.ts:17](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/lib/hash.ts#L17)
 
 ___
 
@@ -119,7 +119,7 @@ ___
 
 #### Defined in
 
-[bindings.ts:353](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/bindings.ts#L353)
+[bindings.ts:353](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/bindings.ts#L353)
 
 ___
 
@@ -135,7 +135,7 @@ ___
 
 #### Defined in
 
-[bindings.ts:225](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/bindings.ts#L225)
+[bindings.ts:225](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/bindings.ts#L225)
 
 ___
 
@@ -161,7 +161,7 @@ ___
 
 #### Defined in
 
-[bindings.ts:201](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/bindings.ts#L201)
+[bindings.ts:201](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/bindings.ts#L201)
 
 ___
 
@@ -171,7 +171,7 @@ ___
 
 #### Defined in
 
-[lib/signer.ts:50](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/lib/signer.ts#L50)
+[lib/signer.ts:50](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/lib/signer.ts#L50)
 
 ## Functions
 
@@ -193,7 +193,7 @@ Creates an instance of the SDK that encompasses a set of global options
 
 #### Defined in
 
-[index.ts:38](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/index.ts#L38)
+[index.ts:38](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/index.ts#L38)
 
 ___
 
@@ -213,4 +213,4 @@ ___
 
 #### Defined in
 
-[lib/signer.ts:64](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/lib/signer.ts#L64)
+[lib/signer.ts:64](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/lib/signer.ts#L64)

--- a/docs/classes/ManifestBuilder.md
+++ b/docs/classes/ManifestBuilder.md
@@ -42,7 +42,7 @@
 
 #### Defined in
 
-[lib/manifestBuilder.ts:41](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/lib/manifestBuilder.ts#L41)
+[lib/manifestBuilder.ts:41](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/lib/manifestBuilder.ts#L41)
 
 ## Properties
 
@@ -52,7 +52,7 @@
 
 #### Defined in
 
-[lib/manifestBuilder.ts:35](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/lib/manifestBuilder.ts#L35)
+[lib/manifestBuilder.ts:35](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/lib/manifestBuilder.ts#L35)
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 #### Defined in
 
-[lib/manifestBuilder.ts:39](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/lib/manifestBuilder.ts#L39)
+[lib/manifestBuilder.ts:39](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/lib/manifestBuilder.ts#L39)
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 #### Defined in
 
-[lib/manifestBuilder.ts:37](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/lib/manifestBuilder.ts#L37)
+[lib/manifestBuilder.ts:37](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/lib/manifestBuilder.ts#L37)
 
 ___
 
@@ -82,7 +82,7 @@ ___
 
 #### Defined in
 
-[lib/manifestBuilder.ts:33](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/lib/manifestBuilder.ts#L33)
+[lib/manifestBuilder.ts:33](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/lib/manifestBuilder.ts#L33)
 
 ## Accessors
 
@@ -96,7 +96,7 @@ ___
 
 #### Defined in
 
-[lib/manifestBuilder.ts:105](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/lib/manifestBuilder.ts#L105)
+[lib/manifestBuilder.ts:105](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/lib/manifestBuilder.ts#L105)
 
 ___
 
@@ -110,7 +110,7 @@ ___
 
 #### Defined in
 
-[lib/manifestBuilder.ts:109](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/lib/manifestBuilder.ts#L109)
+[lib/manifestBuilder.ts:109](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/lib/manifestBuilder.ts#L109)
 
 ## Methods
 
@@ -130,7 +130,7 @@ ___
 
 #### Defined in
 
-[lib/manifestBuilder.ts:72](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/lib/manifestBuilder.ts#L72)
+[lib/manifestBuilder.ts:72](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/lib/manifestBuilder.ts#L72)
 
 ___
 
@@ -150,7 +150,7 @@ ___
 
 #### Defined in
 
-[lib/manifestBuilder.ts:86](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/lib/manifestBuilder.ts#L86)
+[lib/manifestBuilder.ts:86](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/lib/manifestBuilder.ts#L86)
 
 ___
 
@@ -170,7 +170,7 @@ ___
 
 #### Defined in
 
-[lib/manifestBuilder.ts:118](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/lib/manifestBuilder.ts#L118)
+[lib/manifestBuilder.ts:118](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/lib/manifestBuilder.ts#L118)
 
 ___
 
@@ -190,4 +190,4 @@ ___
 
 #### Defined in
 
-[lib/manifestBuilder.ts:95](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/lib/manifestBuilder.ts#L95)
+[lib/manifestBuilder.ts:95](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/lib/manifestBuilder.ts#L95)

--- a/docs/enums/SigningAlgorithm.md
+++ b/docs/enums/SigningAlgorithm.md
@@ -22,7 +22,7 @@
 
 #### Defined in
 
-[lib/signer.ts:16](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/lib/signer.ts#L16)
+[lib/signer.ts:16](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/lib/signer.ts#L16)
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 #### Defined in
 
-[lib/signer.ts:18](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/lib/signer.ts#L18)
+[lib/signer.ts:18](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/lib/signer.ts#L18)
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 #### Defined in
 
-[lib/signer.ts:20](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/lib/signer.ts#L20)
+[lib/signer.ts:20](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/lib/signer.ts#L20)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[lib/signer.ts:28](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/lib/signer.ts#L28)
+[lib/signer.ts:28](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/lib/signer.ts#L28)
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 #### Defined in
 
-[lib/signer.ts:22](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/lib/signer.ts#L22)
+[lib/signer.ts:22](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/lib/signer.ts#L22)
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 #### Defined in
 
-[lib/signer.ts:24](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/lib/signer.ts#L24)
+[lib/signer.ts:24](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/lib/signer.ts#L24)
 
 ___
 
@@ -82,4 +82,4 @@ ___
 
 #### Defined in
 
-[lib/signer.ts:26](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/lib/signer.ts#L26)
+[lib/signer.ts:26](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/lib/signer.ts#L26)

--- a/docs/enums/types.ManifestAssertionKind.md
+++ b/docs/enums/types.ManifestAssertionKind.md
@@ -23,7 +23,7 @@ Assertions in C2PA can be stored in several formats
 
 #### Defined in
 
-[types.d.ts:112](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L112)
+[types.d.ts:112](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L112)
 
 ___
 
@@ -33,7 +33,7 @@ ___
 
 #### Defined in
 
-[types.d.ts:113](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L113)
+[types.d.ts:113](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L113)
 
 ___
 
@@ -43,7 +43,7 @@ ___
 
 #### Defined in
 
-[types.d.ts:114](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L114)
+[types.d.ts:114](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L114)
 
 ___
 
@@ -53,4 +53,4 @@ ___
 
 #### Defined in
 
-[types.d.ts:115](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L115)
+[types.d.ts:115](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L115)

--- a/docs/enums/types.Relationship.md
+++ b/docs/enums/types.Relationship.md
@@ -23,7 +23,7 @@ There can only be one parent ingredient in the ingredients.
 
 #### Defined in
 
-[types.d.ts:272](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L272)
+[types.d.ts:272](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L272)
 
 ___
 
@@ -33,4 +33,4 @@ ___
 
 #### Defined in
 
-[types.d.ts:273](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L273)
+[types.d.ts:273](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L273)

--- a/docs/interfaces/BufferAsset.md
+++ b/docs/interfaces/BufferAsset.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[bindings.ts:138](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/bindings.ts#L138)
+[bindings.ts:138](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/bindings.ts#L138)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[bindings.ts:140](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/bindings.ts#L140)
+[bindings.ts:140](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/bindings.ts#L140)

--- a/docs/interfaces/CreateIngredientProps.md
+++ b/docs/interfaces/CreateIngredientProps.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[bindings.ts:363](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/bindings.ts#L363)
+[bindings.ts:363](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/bindings.ts#L363)
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 #### Defined in
 
-[bindings.ts:370](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/bindings.ts#L370)
+[bindings.ts:370](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/bindings.ts#L370)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[bindings.ts:368](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/bindings.ts#L368)
+[bindings.ts:368](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/bindings.ts#L368)
 
 ___
 
@@ -49,4 +49,4 @@ ___
 
 #### Defined in
 
-[bindings.ts:365](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/bindings.ts#L365)
+[bindings.ts:365](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/bindings.ts#L365)

--- a/docs/interfaces/FileAsset.md
+++ b/docs/interfaces/FileAsset.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[bindings.ts:148](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/bindings.ts#L148)
+[bindings.ts:148](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/bindings.ts#L148)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[bindings.ts:145](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/bindings.ts#L145)
+[bindings.ts:145](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/bindings.ts#L145)

--- a/docs/interfaces/LocalSigner.md
+++ b/docs/interfaces/LocalSigner.md
@@ -20,7 +20,7 @@
 
 #### Defined in
 
-[lib/signer.ts:35](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/lib/signer.ts#L35)
+[lib/signer.ts:35](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/lib/signer.ts#L35)
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 #### Defined in
 
-[lib/signer.ts:33](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/lib/signer.ts#L33)
+[lib/signer.ts:33](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/lib/signer.ts#L33)
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 #### Defined in
 
-[lib/signer.ts:34](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/lib/signer.ts#L34)
+[lib/signer.ts:34](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/lib/signer.ts#L34)
 
 ___
 
@@ -50,7 +50,7 @@ ___
 
 #### Defined in
 
-[lib/signer.ts:36](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/lib/signer.ts#L36)
+[lib/signer.ts:36](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/lib/signer.ts#L36)
 
 ___
 
@@ -60,4 +60,4 @@ ___
 
 #### Defined in
 
-[lib/signer.ts:32](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/lib/signer.ts#L32)
+[lib/signer.ts:32](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/lib/signer.ts#L32)

--- a/docs/interfaces/RemoteSigner.md
+++ b/docs/interfaces/RemoteSigner.md
@@ -26,7 +26,7 @@
 
 #### Defined in
 
-[lib/signer.ts:46](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/lib/signer.ts#L46)
+[lib/signer.ts:46](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/lib/signer.ts#L46)
 
 ___
 
@@ -50,7 +50,7 @@ ___
 
 #### Defined in
 
-[lib/signer.ts:47](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/lib/signer.ts#L47)
+[lib/signer.ts:47](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/lib/signer.ts#L47)
 
 ___
 
@@ -60,4 +60,4 @@ ___
 
 #### Defined in
 
-[lib/signer.ts:45](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/lib/signer.ts#L45)
+[lib/signer.ts:45](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/lib/signer.ts#L45)

--- a/docs/interfaces/ResolvedIngredient.md
+++ b/docs/interfaces/ResolvedIngredient.md
@@ -23,7 +23,7 @@
 
 #### Defined in
 
-[bindings.ts:79](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/bindings.ts#L79)
+[bindings.ts:79](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/bindings.ts#L79)
 
 ___
 
@@ -33,4 +33,4 @@ ___
 
 #### Defined in
 
-[bindings.ts:80](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/bindings.ts#L80)
+[bindings.ts:80](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/bindings.ts#L80)

--- a/docs/interfaces/ResolvedManifest.md
+++ b/docs/interfaces/ResolvedManifest.md
@@ -24,7 +24,7 @@
 
 #### Defined in
 
-[bindings.ts:52](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/bindings.ts#L52)
+[bindings.ts:52](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/bindings.ts#L52)
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 #### Defined in
 
-[bindings.ts:54](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/bindings.ts#L54)
+[bindings.ts:54](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/bindings.ts#L54)
 
 ___
 
@@ -44,4 +44,4 @@ ___
 
 #### Defined in
 
-[bindings.ts:53](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/bindings.ts#L53)
+[bindings.ts:53](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/bindings.ts#L53)

--- a/docs/interfaces/ResolvedManifestStore.md
+++ b/docs/interfaces/ResolvedManifestStore.md
@@ -23,7 +23,7 @@
 
 #### Defined in
 
-[bindings.ts:59](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/bindings.ts#L59)
+[bindings.ts:59](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/bindings.ts#L59)
 
 ___
 
@@ -33,4 +33,4 @@ ___
 
 #### Defined in
 
-[bindings.ts:60](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/bindings.ts#L60)
+[bindings.ts:60](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/bindings.ts#L60)

--- a/docs/interfaces/ResolvedResource.md
+++ b/docs/interfaces/ResolvedResource.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[bindings.ts:43](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/bindings.ts#L43)
+[bindings.ts:43](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/bindings.ts#L43)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[bindings.ts:42](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/bindings.ts#L42)
+[bindings.ts:42](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/bindings.ts#L42)

--- a/docs/interfaces/ResolvedSignatureInfo.md
+++ b/docs/interfaces/ResolvedSignatureInfo.md
@@ -32,7 +32,7 @@ human readable issuing authority for this signature
 
 #### Defined in
 
-[types.d.ts:308](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L308)
+[types.d.ts:308](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L308)
 
 ___
 
@@ -48,7 +48,7 @@ the time the signature was created
 
 #### Defined in
 
-[types.d.ts:312](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L312)
+[types.d.ts:312](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L312)
 
 ___
 
@@ -58,4 +58,4 @@ ___
 
 #### Defined in
 
-[bindings.ts:47](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/bindings.ts#L47)
+[bindings.ts:47](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/bindings.ts#L47)

--- a/docs/interfaces/SignClaimBytesProps.md
+++ b/docs/interfaces/SignClaimBytesProps.md
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-[bindings.ts:215](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/bindings.ts#L215)
+[bindings.ts:215](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/bindings.ts#L215)
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 #### Defined in
 
-[bindings.ts:216](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/bindings.ts#L216)
+[bindings.ts:216](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/bindings.ts#L216)
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 #### Defined in
 
-[bindings.ts:217](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/bindings.ts#L217)
+[bindings.ts:217](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/bindings.ts#L217)

--- a/docs/interfaces/SignInput.md
+++ b/docs/interfaces/SignInput.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[lib/signer.ts:40](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/lib/signer.ts#L40)
+[lib/signer.ts:40](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/lib/signer.ts#L40)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[lib/signer.ts:41](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/lib/signer.ts#L41)
+[lib/signer.ts:41](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/lib/signer.ts#L41)

--- a/docs/interfaces/SignOptions.md
+++ b/docs/interfaces/SignOptions.md
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-[bindings.ts:196](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/bindings.ts#L196)
+[bindings.ts:196](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/bindings.ts#L196)
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 #### Defined in
 
-[bindings.ts:197](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/bindings.ts#L197)
+[bindings.ts:197](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/bindings.ts#L197)
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 #### Defined in
 
-[bindings.ts:198](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/bindings.ts#L198)
+[bindings.ts:198](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/bindings.ts#L198)

--- a/docs/interfaces/StorableIngredient.md
+++ b/docs/interfaces/StorableIngredient.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[bindings.ts:356](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/bindings.ts#L356)
+[bindings.ts:356](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/bindings.ts#L356)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[bindings.ts:357](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/bindings.ts#L357)
+[bindings.ts:357](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/bindings.ts#L357)

--- a/docs/interfaces/ThumbnailOptions.md
+++ b/docs/interfaces/ThumbnailOptions.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[lib/thumbnail.ts:15](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/lib/thumbnail.ts#L15)
+[lib/thumbnail.ts:15](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/lib/thumbnail.ts#L15)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[lib/thumbnail.ts:16](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/lib/thumbnail.ts#L16)
+[lib/thumbnail.ts:16](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/lib/thumbnail.ts#L16)

--- a/docs/interfaces/types.Actor.md
+++ b/docs/interfaces/types.Actor.md
@@ -27,7 +27,7 @@ List of references to W3C Verifiable Credentials.
 
 #### Defined in
 
-[types.d.ts:234](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L234)
+[types.d.ts:234](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L234)
 
 ___
 
@@ -39,4 +39,4 @@ An identifier for a human actor, used when the "type" is `humanEntry.identified`
 
 #### Defined in
 
-[types.d.ts:238](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L238)
+[types.d.ts:238](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L238)

--- a/docs/interfaces/types.DataSource.md
+++ b/docs/interfaces/types.DataSource.md
@@ -28,7 +28,7 @@ A list of [`Actor`]s associated with this source.
 
 #### Defined in
 
-[types.d.ts:215](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L215)
+[types.d.ts:215](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L215)
 
 ___
 
@@ -40,7 +40,7 @@ A human-readable string giving details about the source of the assertion data.
 
 #### Defined in
 
-[types.d.ts:219](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L219)
+[types.d.ts:219](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L219)
 
 ___
 
@@ -52,4 +52,4 @@ A value from among the enumerated list indicating the source of the assertion.
 
 #### Defined in
 
-[types.d.ts:223](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L223)
+[types.d.ts:223](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L223)

--- a/docs/interfaces/types.HashedURI.md
+++ b/docs/interfaces/types.HashedURI.md
@@ -27,7 +27,7 @@ tagged cbor serialization
 
 #### Defined in
 
-[types.d.ts:247](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L247)
+[types.d.ts:247](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L247)
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 #### Defined in
 
-[types.d.ts:248](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L248)
+[types.d.ts:248](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L248)
 
 ___
 
@@ -47,4 +47,4 @@ ___
 
 #### Defined in
 
-[types.d.ts:249](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L249)
+[types.d.ts:249](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L249)

--- a/docs/interfaces/types.Ingredient.md
+++ b/docs/interfaces/types.Ingredient.md
@@ -43,7 +43,7 @@ If this ingredient has a [`ManifestStore`], this will hold the label of the acti
 
 #### Defined in
 
-[types.d.ts:130](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L130)
+[types.d.ts:130](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L130)
 
 ___
 
@@ -55,7 +55,7 @@ Document ID from `xmpMM:DocumentID` in XMP metadata.
 
 #### Defined in
 
-[types.d.ts:134](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L134)
+[types.d.ts:134](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L134)
 
 ___
 
@@ -67,7 +67,7 @@ The format of the source file as a MIME type.
 
 #### Defined in
 
-[types.d.ts:138](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L138)
+[types.d.ts:138](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L138)
 
 ___
 
@@ -79,7 +79,7 @@ An optional hash of the asset to prevent duplicates.
 
 #### Defined in
 
-[types.d.ts:142](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L142)
+[types.d.ts:142](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L142)
 
 ___
 
@@ -91,7 +91,7 @@ Instance ID from `xmpMM:InstanceID` in XMP metadata.
 
 #### Defined in
 
-[types.d.ts:146](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L146)
+[types.d.ts:146](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L146)
 
 ___
 
@@ -105,7 +105,7 @@ A [`ManifestStore`] from the source asset extracted as a binary C2PA blob.
 
 #### Defined in
 
-[types.d.ts:152](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L152)
+[types.d.ts:152](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L152)
 
 ___
 
@@ -119,7 +119,7 @@ Any additional [`Metadata`] as defined in the C2PA spec.
 
 #### Defined in
 
-[types.d.ts:158](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L158)
+[types.d.ts:158](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L158)
 
 ___
 
@@ -131,7 +131,7 @@ URI from `dcterms:provenance` in XMP metadata.
 
 #### Defined in
 
-[types.d.ts:162](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L162)
+[types.d.ts:162](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L162)
 
 ___
 
@@ -145,7 +145,7 @@ There can only be one parent ingredient in the ingredients.
 
 #### Defined in
 
-[types.d.ts:168](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L168)
+[types.d.ts:168](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L168)
 
 ___
 
@@ -155,7 +155,7 @@ ___
 
 #### Defined in
 
-[types.d.ts:169](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L169)
+[types.d.ts:169](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L169)
 
 ___
 
@@ -169,7 +169,7 @@ A tuple of thumbnail MIME format (i.e. `image/jpeg`) and binary bits of the imag
 
 #### Defined in
 
-[types.d.ts:175](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L175)
+[types.d.ts:175](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L175)
 
 ___
 
@@ -181,7 +181,7 @@ A human-readable title, generally source filename.
 
 #### Defined in
 
-[types.d.ts:179](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L179)
+[types.d.ts:179](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L179)
 
 ___
 
@@ -193,4 +193,4 @@ Validation results.
 
 #### Defined in
 
-[types.d.ts:183](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L183)
+[types.d.ts:183](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L183)

--- a/docs/interfaces/types.Manifest.md
+++ b/docs/interfaces/types.Manifest.md
@@ -39,7 +39,7 @@ A list of assertions
 
 #### Defined in
 
-[types.d.ts:36](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L36)
+[types.d.ts:36](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L36)
 
 ___
 
@@ -52,7 +52,7 @@ claim Spaces are not allowed in names, versions can be specified with product/1.
 
 #### Defined in
 
-[types.d.ts:41](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L41)
+[types.d.ts:41](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L41)
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 #### Defined in
 
-[types.d.ts:42](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L42)
+[types.d.ts:42](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L42)
 
 ___
 
@@ -74,7 +74,7 @@ A List of verified credentials
 
 #### Defined in
 
-[types.d.ts:46](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L46)
+[types.d.ts:46](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L46)
 
 ___
 
@@ -86,7 +86,7 @@ The format of the source file as a MIME type.
 
 #### Defined in
 
-[types.d.ts:50](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L50)
+[types.d.ts:50](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L50)
 
 ___
 
@@ -98,7 +98,7 @@ A List of ingredients
 
 #### Defined in
 
-[types.d.ts:54](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L54)
+[types.d.ts:54](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L54)
 
 ___
 
@@ -110,7 +110,7 @@ Instance ID from `xmpMM:InstanceID` in XMP metadata.
 
 #### Defined in
 
-[types.d.ts:58](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L58)
+[types.d.ts:58](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L58)
 
 ___
 
@@ -120,7 +120,7 @@ ___
 
 #### Defined in
 
-[types.d.ts:59](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L59)
+[types.d.ts:59](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L59)
 
 ___
 
@@ -132,7 +132,7 @@ A list of redactions - URIs to a redacted assertions
 
 #### Defined in
 
-[types.d.ts:63](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L63)
+[types.d.ts:63](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L63)
 
 ___
 
@@ -144,7 +144,7 @@ container for binary assets (like thumbnails)
 
 #### Defined in
 
-[types.d.ts:67](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L67)
+[types.d.ts:67](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L67)
 
 ___
 
@@ -156,7 +156,7 @@ Signature data (only used for reporting)
 
 #### Defined in
 
-[types.d.ts:71](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L71)
+[types.d.ts:71](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L71)
 
 ___
 
@@ -166,7 +166,7 @@ ___
 
 #### Defined in
 
-[types.d.ts:72](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L72)
+[types.d.ts:72](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L72)
 
 ___
 
@@ -178,7 +178,7 @@ A human-readable title, generally source filename.
 
 #### Defined in
 
-[types.d.ts:76](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L76)
+[types.d.ts:76](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L76)
 
 ___
 
@@ -191,4 +191,4 @@ name for the vendor (i.e. `adobe`)
 
 #### Defined in
 
-[types.d.ts:81](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L81)
+[types.d.ts:81](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L81)

--- a/docs/interfaces/types.ManifestAssertion.md
+++ b/docs/interfaces/types.ManifestAssertion.md
@@ -29,7 +29,7 @@ The data of the assertion as Value
 
 #### Defined in
 
-[types.d.ts:92](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L92)
+[types.d.ts:92](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L92)
 
 ___
 
@@ -41,7 +41,7 @@ There can be more than one assertion for any label
 
 #### Defined in
 
-[types.d.ts:96](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L96)
+[types.d.ts:96](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L96)
 
 ___
 
@@ -53,7 +53,7 @@ The [ManifestAssertionKind] for this assertion (as stored in c2pa content)
 
 #### Defined in
 
-[types.d.ts:100](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L100)
+[types.d.ts:100](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L100)
 
 ___
 
@@ -65,4 +65,4 @@ An assertion label in reverse domain format
 
 #### Defined in
 
-[types.d.ts:104](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L104)
+[types.d.ts:104](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L104)

--- a/docs/interfaces/types.ManifestStore.md
+++ b/docs/interfaces/types.ManifestStore.md
@@ -28,7 +28,7 @@ A label for the active (most recent) manifest in the store
 
 #### Defined in
 
-[types.d.ts:17](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L17)
+[types.d.ts:17](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L17)
 
 ___
 
@@ -44,7 +44,7 @@ A HashMap of Manifests
 
 #### Defined in
 
-[types.d.ts:21](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L21)
+[types.d.ts:21](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L21)
 
 ___
 
@@ -56,4 +56,4 @@ ValidationStatus generated when loading the ManifestStore from an asset
 
 #### Defined in
 
-[types.d.ts:25](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L25)
+[types.d.ts:25](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L25)

--- a/docs/interfaces/types.Metadata.md
+++ b/docs/interfaces/types.Metadata.md
@@ -28,7 +28,7 @@ others
 
 #### Defined in
 
-[types.d.ts:201](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L201)
+[types.d.ts:201](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L201)
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 #### Defined in
 
-[types.d.ts:202](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L202)
+[types.d.ts:202](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L202)
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 #### Defined in
 
-[types.d.ts:203](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L203)
+[types.d.ts:203](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L203)
 
 ___
 
@@ -58,4 +58,4 @@ ___
 
 #### Defined in
 
-[types.d.ts:204](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L204)
+[types.d.ts:204](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L204)

--- a/docs/interfaces/types.ResourceRef.md
+++ b/docs/interfaces/types.ResourceRef.md
@@ -25,7 +25,7 @@ A reference to a resource to be used in JSON serialization
 
 #### Defined in
 
-[types.d.ts:191](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L191)
+[types.d.ts:191](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L191)
 
 ___
 
@@ -35,4 +35,4 @@ ___
 
 #### Defined in
 
-[types.d.ts:192](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L192)
+[types.d.ts:192](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L192)

--- a/docs/interfaces/types.ResourceStore.md
+++ b/docs/interfaces/types.ResourceStore.md
@@ -27,7 +27,7 @@ container for binary assets (like thumbnails)
 
 #### Defined in
 
-[types.d.ts:282](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L282)
+[types.d.ts:282](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L282)
 
 ___
 
@@ -41,4 +41,4 @@ ___
 
 #### Defined in
 
-[types.d.ts:283](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L283)
+[types.d.ts:283](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L283)

--- a/docs/interfaces/types.ReviewRating.md
+++ b/docs/interfaces/types.ReviewRating.md
@@ -29,7 +29,7 @@ See
 
 #### Defined in
 
-[types.d.ts:260](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L260)
+[types.d.ts:260](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L260)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[types.d.ts:261](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L261)
+[types.d.ts:261](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L261)
 
 ___
 
@@ -49,4 +49,4 @@ ___
 
 #### Defined in
 
-[types.d.ts:262](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L262)
+[types.d.ts:262](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L262)

--- a/docs/interfaces/types.SignatureInfo.md
+++ b/docs/interfaces/types.SignatureInfo.md
@@ -33,7 +33,7 @@ human readable issuing authority for this signature
 
 #### Defined in
 
-[types.d.ts:308](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L308)
+[types.d.ts:308](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L308)
 
 ___
 
@@ -45,4 +45,4 @@ the time the signature was created
 
 #### Defined in
 
-[types.d.ts:312](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L312)
+[types.d.ts:312](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L312)

--- a/docs/interfaces/types.ValidationStatus.md
+++ b/docs/interfaces/types.ValidationStatus.md
@@ -30,7 +30,7 @@ See
 
 #### Defined in
 
-[types.d.ts:295](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L295)
+[types.d.ts:295](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L295)
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 #### Defined in
 
-[types.d.ts:296](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L296)
+[types.d.ts:296](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L296)
 
 ___
 
@@ -50,4 +50,4 @@ ___
 
 #### Defined in
 
-[types.d.ts:297](https://github.com/contentauth/c2pa-node/blob/ba516c3/js-src/types.d.ts#L297)
+[types.d.ts:297](https://github.com/contentauth/c2pa-node/blob/17fd396/js-src/types.d.ts#L297)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,11 +87,12 @@ fn process_store(
 fn read(mut cx: FunctionContext) -> JsResult<JsPromise> {
     let rt = runtime(&mut cx)?;
     let channel = cx.channel();
-    let (deferred, promise) = cx.promise();
 
     let asset = cx
         .argument::<JsObject>(0)
         .and_then(|obj| parse_asset(&mut cx, obj))?;
+
+    let (deferred, promise) = cx.promise();
 
     rt.spawn(async move {
         let store = match &asset {
@@ -147,11 +148,12 @@ fn process_ingredient(
 fn create_ingredient(mut cx: FunctionContext) -> JsResult<JsPromise> {
     let rt = runtime(&mut cx)?;
     let channel = cx.channel();
-    let (deferred, promise) = cx.promise();
 
     let asset = cx
         .argument::<JsObject>(0)
         .and_then(|obj| parse_asset(&mut cx, obj))?;
+
+    let (deferred, promise) = cx.promise();
 
     rt.spawn(async move {
         let ingredient = self::ingredient::create_ingredient(&asset).await;

--- a/src/sign/mod.rs
+++ b/src/sign/mod.rs
@@ -300,7 +300,6 @@ fn create_sign_response(
 pub fn sign(mut cx: FunctionContext) -> JsResult<JsPromise> {
     let rt = runtime(&mut cx)?;
     let channel = cx.channel();
-    let (deferred, promise) = cx.promise();
 
     let manifest_repr = cx
         .argument::<JsObject>(0)
@@ -311,6 +310,8 @@ pub fn sign(mut cx: FunctionContext) -> JsResult<JsPromise> {
     let options = cx
         .argument::<JsObject>(2)
         .and_then(|opts| parse_options(&mut cx, opts))?;
+
+    let (deferred, promise) = cx.promise();
 
     rt.spawn(async move {
         let is_buffer = matches!(&input_asset, Asset::Buffer(_, _));
@@ -353,13 +354,14 @@ pub fn sign(mut cx: FunctionContext) -> JsResult<JsPromise> {
 pub fn sign_claim_bytes(mut cx: FunctionContext) -> JsResult<JsPromise> {
     let rt = runtime(&mut cx)?;
     let channel = cx.channel();
-    let (deferred, promise) = cx.promise();
 
     let claim = cx.argument::<JsBuffer>(0)?.as_slice(&cx).to_vec();
     let reserve_size = cx.argument::<JsNumber>(1)?.value(&mut cx) as usize;
     let signer_config = cx
         .argument::<JsObject>(2)
         .and_then(|opts| signer_config_from_opts(&mut cx, &opts))?;
+
+    let (deferred, promise) = cx.promise();
 
     rt.spawn(async move {
         let signer = match signer_config {

--- a/tests/read.test.ts
+++ b/tests/read.test.ts
@@ -10,12 +10,21 @@
 import { readFile } from 'node:fs/promises';
 import { C2pa, createC2pa } from '../dist/js-src/index';
 import type { ManifestAssertion } from '../dist/js-src/types';
+import { RemoteSigner, SignInput } from '../js-src';
 
 describe('read()', () => {
   let c2pa: C2pa;
 
   beforeEach(() => {
     c2pa = createC2pa();
+  });
+
+  // CAI-4527
+  test('should handle incorrect argument types and not leave unsettled `Deferred` types', async () => {
+    await expect(async () => {
+      // @ts-ignore - doing this on purpose to simulate environment without types
+      return await c2pa.read(null);
+    }).rejects.toThrow(/failed to downcast any to object/);
   });
 
   test('should read a JPEG image with an embedded manifest', async () => {


### PR DESCRIPTION
The logs in provided to us by the reporter of the ticket included this error: 

```
neon::types::Deferred` was dropped without being settled
```

This occurs when a `Deferred` struct is created but not settled. Our code was creating the deferred values, then parsing arguments of the JS invocation of our APIs. If this parsing failed, the `deffered` value would never be settled, which causes the panic. The added test will fail if the `deferred` value is not settled.